### PR TITLE
Prevent modal from closing on outside click

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -465,8 +465,8 @@ export default function Home() {
         <div className="w-full max-w-[95%] mx-auto flex flex-col sm:flex-row justify-between items-center gap-4">
           <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
             <DialogTrigger asChild>
-              <Button 
-                variant="secondary" 
+              <Button
+                variant="secondary"
                 rounded="lg"
                 className="bg-white/90 hover:bg-white text-indigo-600"
               >
@@ -474,7 +474,11 @@ export default function Home() {
                 Ajouter une recette
               </Button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[425px] bg-gradient-to-b from-white to-indigo-50/30 border-2 border-indigo-200">
+            <DialogContent
+              className="sm:max-w-[425px] bg-gradient-to-b from-white to-indigo-50/30 border-2 border-indigo-200"
+              disableOutsideClose
+              hideCloseButton
+            >
               <DialogHeader>
                 <DialogTitle className="text-2xl gradient-heading">
                   {editingRecipe ? "Modifier la recette" : "Nouvelle Recette"}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -29,28 +29,63 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  /**
+   * Hides the default close button rendered in the top right corner.
+   */
+  hideCloseButton?: boolean;
+  /**
+   * Prevents closing the dialog when clicking outside or pressing escape.
+   */
+  disableOutsideClose?: boolean;
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+  DialogContentProps
+>(
+  (
+    {
+      className,
+      children,
+      hideCloseButton,
+      disableOutsideClose,
+      onInteractOutside,
+      onEscapeKeyDown,
+      ...props
+    },
+    ref
+  ) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          className
+        )}
+        onInteractOutside={(e) => {
+          if (disableOutsideClose) e.preventDefault();
+          onInteractOutside?.(e);
+        }}
+        onEscapeKeyDown={(e) => {
+          if (disableOutsideClose) e.preventDefault();
+          onEscapeKeyDown?.(e);
+        }}
+        {...props}
+      >
+        {children}
+        {!hideCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({


### PR DESCRIPTION
## Summary
- update dialog component to support disabling outside click and optional close button
- keep recipe dialog open on outside clicks and remove the default close icon

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877fa0f7648832c8960499112365179